### PR TITLE
Refactor token selection to use event delegation

### DIFF
--- a/app.js
+++ b/app.js
@@ -171,7 +171,18 @@
                 this.querySelector('div').style.background = 'transparent';
             });
         });
-        
+
+        // Token selection via event delegation
+        document.querySelectorAll('.token-list').forEach(list => {
+            list.addEventListener('click', (event) => {
+                const tokenItem = event.target.closest('.token-item');
+                if (tokenItem) {
+                    const token = tokenItem.dataset.token;
+                    selectToken(token);
+                }
+            });
+        });
+
         // Simulate loading states
         function showLoadingState() {
             const skeleton = document.createElement('div');

--- a/front
+++ b/front
@@ -414,7 +414,7 @@
                 </div>
                 
                 <div class="token-list">
-                    <div class="token-item" onclick="selectToken('AAA')">
+                    <div class="token-item" data-token="AAA">
                         <div class="flex items-center justify-between" style="padding: var(--s2); cursor: pointer; border-radius: var(--radius-md);">
                             <div class="flex items-center gap-2">
                                 <div class="token-icon"></div>
@@ -426,7 +426,7 @@
                             <div class="text-mono">1,234.56</div>
                         </div>
                     </div>
-                    <div class="token-item" onclick="selectToken('BBB')">
+                    <div class="token-item" data-token="BBB">
                         <div class="flex items-center justify-between" style="padding: var(--s2); cursor: pointer; border-radius: var(--radius-md);">
                             <div class="flex items-center gap-2">
                                 <div class="token-icon" style="background: linear-gradient(135deg, #F59E0B, #EF4444)"></div>
@@ -438,7 +438,7 @@
                             <div class="text-mono">567.89</div>
                         </div>
                     </div>
-                    <div class="token-item" onclick="selectToken('USDC')">
+                    <div class="token-item" data-token="USDC">
                         <div class="flex items-center justify-between" style="padding: var(--s2); cursor: pointer; border-radius: var(--radius-md);">
                             <div class="flex items-center gap-2">
                                 <div class="token-icon" style="background: linear-gradient(135deg, #10B981, #3B82F6)"></div>


### PR DESCRIPTION
## Summary
- remove inline token selection handlers from HTML
- add `data-token` attributes to token items
- handle token selection via delegated click listener

## Testing
- `node --check app.js && echo "syntax ok"`


------
https://chatgpt.com/codex/tasks/task_e_68bd9ca00b14832f8631e58e16052e04