### PR TITLE
Refactor slippage and token hover handling

### DIFF
--- a/app.js
+++ b/app.js
@@ -154,34 +154,41 @@
             }
         });
         
-        // Slippage button handlers
-        document.querySelectorAll('.slippage-btn').forEach(btn => {
-            btn.addEventListener('click', function() {
-                this.parentElement.querySelectorAll('.slippage-btn').forEach(b => b.classList.remove('active'));
-                this.classList.add('active');
-            });
-        });
-        
-        // Add smooth hover effects to token items
-        document.querySelectorAll('.token-item').forEach(item => {
-            item.addEventListener('mouseenter', function() {
-                this.querySelector('div').style.background = 'var(--bg-elev)';
-            });
-            item.addEventListener('mouseleave', function() {
-                this.querySelector('div').style.background = 'transparent';
+        // Slippage button handlers via event delegation
+        document.querySelectorAll('.slippage-options').forEach(container => {
+            container.addEventListener('click', (event) => {
+                const btn = event.target.closest('.slippage-btn');
+                if (!btn) return;
+                container.querySelectorAll('.slippage-btn').forEach(b => b.classList.remove('active'));
+                btn.classList.add('active');
             });
         });
 
-        // Token selection via event delegation
-        document.querySelectorAll('.token-list').forEach(list => {
-            list.addEventListener('click', (event) => {
+        // Token list hover and selection using event delegation
+        const tokenList = document.querySelector('.token-list');
+        if (tokenList) {
+            tokenList.addEventListener('mouseenter', (event) => {
+                const item = event.target.closest('.token-item');
+                if (item && tokenList.contains(item)) {
+                    item.classList.add('hover');
+                }
+            }, true);
+
+            tokenList.addEventListener('mouseleave', (event) => {
+                const item = event.target.closest('.token-item');
+                if (item && tokenList.contains(item)) {
+                    item.classList.remove('hover');
+                }
+            }, true);
+
+            tokenList.addEventListener('click', (event) => {
                 const tokenItem = event.target.closest('.token-item');
                 if (tokenItem) {
                     const token = tokenItem.dataset.token;
                     selectToken(token);
                 }
             });
-        });
+        }
 
         // Simulate loading states
         function showLoadingState() {

--- a/styles.css
+++ b/styles.css
@@ -406,12 +406,16 @@
         .token-select:hover {
             border-color: var(--brand);
         }
-        
+
         .token-icon {
             width: 24px;
             height: 24px;
             border-radius: 50%;
             background: linear-gradient(135deg, var(--brand), var(--info));
+        }
+
+        .token-item.hover > div {
+            background: var(--bg-elev);
         }
         
         /* Swap Interface */


### PR DESCRIPTION
## Summary
- Use event delegation on `.slippage-options` to manage slippage buttons
- Delegate hover and click interactions within `.token-list`
- Add CSS for `.token-item.hover` styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd9e997830832fb5cf9de44aded447