### PR TITLE
Extract token-row styling from inline to CSS

### DIFF
--- a/front
+++ b/front
@@ -415,7 +415,7 @@
                 
                 <div class="token-list">
                     <div class="token-item" data-token="AAA">
-                        <div class="flex items-center justify-between" style="padding: var(--s2); cursor: pointer; border-radius: var(--radius-md);">
+                        <div class="flex items-center justify-between token-row">
                             <div class="flex items-center gap-2">
                                 <div class="token-icon"></div>
                                 <div>
@@ -427,7 +427,7 @@
                         </div>
                     </div>
                     <div class="token-item" data-token="BBB">
-                        <div class="flex items-center justify-between" style="padding: var(--s2); cursor: pointer; border-radius: var(--radius-md);">
+                        <div class="flex items-center justify-between token-row">
                             <div class="flex items-center gap-2">
                                 <div class="token-icon" style="background: linear-gradient(135deg, #F59E0B, #EF4444)"></div>
                                 <div>
@@ -439,7 +439,7 @@
                         </div>
                     </div>
                     <div class="token-item" data-token="USDC">
-                        <div class="flex items-center justify-between" style="padding: var(--s2); cursor: pointer; border-radius: var(--radius-md);">
+                        <div class="flex items-center justify-between token-row">
                             <div class="flex items-center gap-2">
                                 <div class="token-icon" style="background: linear-gradient(135deg, #10B981, #3B82F6)"></div>
                                 <div>

--- a/styles.css
+++ b/styles.css
@@ -414,6 +414,12 @@
             background: linear-gradient(135deg, var(--brand), var(--info));
         }
 
+        .token-row {
+            padding: var(--s2);
+            cursor: pointer;
+            border-radius: var(--radius-md);
+        }
+
         .token-item.hover > div {
             background: var(--bg-elev);
         }


### PR DESCRIPTION
## Summary
- add `.token-row` class encapsulating padding, cursor and border-radius
- use `.token-row` for token list rows and remove inline styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bda0a52544832f9667370171482b18