### PR TITLE
Add token metadata validation and custom token support

### DIFF
--- a/index.html
+++ b/index.html
@@ -350,59 +350,14 @@
                 <button class="btn btn-ghost btn-sm" onclick="closeModal('tokenModal')">✕</button>
             </div>
             <div class="modal-body">
-                <input type="text" class="input w-full mb-3" placeholder="Search name or paste address">
-                
+                <input id="tokenSearch" type="text" class="input w-full mb-3" placeholder="Search name or paste address">
+
                 <div class="mb-3">
                     <div class="text-sm text-muted mb-2">Popular tokens</div>
-                    <div class="flex gap-2">
-                        <button class="btn btn-secondary btn-sm">ETH</button>
-                        <button class="btn btn-secondary btn-sm">USDC</button>
-                        <button class="btn btn-secondary btn-sm">AAA</button>
-                        <button class="btn btn-secondary btn-sm">BBB</button>
-                    </div>
+                    <div id="popularTokens" class="flex gap-2"></div>
                 </div>
-                
-                <div class="token-list">
-                    <div class="token-item" data-token="AAA">
-                        <div class="flex items-center justify-between token-row">
-                            <div class="flex items-center gap-2">
-                                <div class="token-icon"></div>
-                                <div>
-                                    <div>AAA</div>
-                                    <div class="text-xs text-muted">AAA Token</div>
-                                </div>
-                            </div>
-                            <div class="text-mono">1,234.56</div>
-                        </div>
-                    </div>
-                    <div class="token-item" data-token="BBB">
-                        <div class="flex items-center justify-between token-row">
-                            <div class="flex items-center gap-2">
-                                <div class="token-icon" style="background: linear-gradient(135deg, #F59E0B, #EF4444)"></div>
-                                <div>
-                                    <div>BBB</div>
-                                    <div class="text-xs text-muted">BBB Token</div>
-                                </div>
-                            </div>
-                            <div class="text-mono">567.89</div>
-                        </div>
-                    </div>
-                    <div class="token-item" data-token="USDC">
-                        <div class="flex items-center justify-between token-row">
-                            <div class="flex items-center gap-2">
-                                <div class="token-icon" style="background: linear-gradient(135deg, #10B981, #3B82F6)"></div>
-                                <div>
-                                    <div class="flex items-center gap-1">
-                                        USDC
-                                        <span class="badge badge-warning">⚠️</span>
-                                    </div>
-                                    <div class="text-xs text-muted">USD Coin</div>
-                                </div>
-                            </div>
-                            <div class="text-mono">10,000.00</div>
-                        </div>
-                    </div>
-                </div>
+
+                <div id="tokenList" class="token-list"></div>
             </div>
         </div>
     </div>

--- a/tokens.json
+++ b/tokens.json
@@ -1,0 +1,23 @@
+[
+  {
+    "address": "0x000000000000000000000000000000000000000A",
+    "symbol": "AAA",
+    "name": "AAA Token",
+    "decimals": 18,
+    "icon": "https://via.placeholder.com/32/627eea/ffffff?text=A"
+  },
+  {
+    "address": "0x000000000000000000000000000000000000000B",
+    "symbol": "BBB",
+    "name": "BBB Token",
+    "decimals": 18,
+    "icon": "https://via.placeholder.com/32/f59e0b/ffffff?text=B"
+  },
+  {
+    "address": "0x000000000000000000000000000000000000000C",
+    "symbol": "USDC",
+    "name": "USD Coin",
+    "decimals": 6,
+    "icon": "https://via.placeholder.com/32/2775ca/ffffff?text=U"
+  }
+]


### PR DESCRIPTION
## Summary
- add `tokens.json` with sample token metadata
- dynamically load tokens, fetch ERC20 symbol/decimals, and warn on mismatches
- cache token metadata and allow importing custom tokens by address

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb03111e4832fa385d59b173a14a2