### PR TITLE
Use BigInt utilities for token unit conversions

### DIFF
--- a/src/pools.js
+++ b/src/pools.js
@@ -1,6 +1,7 @@
 const { ethers } = require('ethers');
 const dexAdapter = require('./adapters/dexAdapter');
 const addresses = require('../contractMap.json');
+const { fromBaseUnits } = require('./utils');
 
 async function defaultPriceOracle() {
   // Placeholder price oracle - returns 1 USD for any token
@@ -17,13 +18,13 @@ async function getPools(provider, priceOracle = defaultPriceOracle) {
         results.push({ ...pair, error: 'Pool not found' });
         continue;
       }
-      const reserveA = state.reserves[pair.tokenA.toLowerCase()] || '0';
-      const reserveB = state.reserves[pair.tokenB.toLowerCase()] || '0';
+      const reserveA = BigInt(state.reserves[pair.tokenA.toLowerCase()] || '0');
+      const reserveB = BigInt(state.reserves[pair.tokenB.toLowerCase()] || '0');
       const priceA = await priceOracle(pair.tokenA);
       const priceB = await priceOracle(pair.tokenB);
       const tvl =
-        parseFloat(ethers.utils.formatUnits(reserveA, 18)) * priceA +
-        parseFloat(ethers.utils.formatUnits(reserveB, 18)) * priceB;
+        parseFloat(fromBaseUnits(reserveA, 18)) * priceA +
+        parseFloat(fromBaseUnits(reserveB, 18)) * priceB;
       results.push({
         ...pair,
         pairAddress: state.pairAddress,

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,18 @@
+function toBaseUnits(amount, decimals) {
+  const [whole = '0', fraction = ''] = String(amount).split('.');
+  const frac = fraction.padEnd(decimals, '0').slice(0, decimals);
+  const wholeBig = BigInt(whole);
+  const fracBig = BigInt(frac || '0');
+  return wholeBig * 10n ** BigInt(decimals) + fracBig;
+}
+
+function fromBaseUnits(amount, decimals) {
+  const base = 10n ** BigInt(decimals);
+  const value = BigInt(amount);
+  const whole = value / base;
+  const fraction = value % base;
+  const fracStr = fraction.toString().padStart(decimals, '0').replace(/0+$/, '');
+  return fracStr ? `${whole.toString()}.${fracStr}` : whole.toString();
+}
+
+module.exports = { toBaseUnits, fromBaseUnits };


### PR DESCRIPTION
## Summary
- add BigInt-based `toBaseUnits`/`fromBaseUnits` helpers
- refactor swap and liquidity flows to parse and format amounts with these helpers
- compute pool TVL using BigInt conversions

## Testing
- `node --check src/utils.js`
- `node --check src/pools.js`
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68bdb21ca144832fab3be3e73c2a2548