### PR TITLE
Validate RPC URL before provider initialization

### DIFF
--- a/app.js
+++ b/app.js
@@ -14,10 +14,17 @@
         const sepoliaConfig = window.networkConfig[DEFAULT_CHAIN_ID];
         let provider;
 
-        if (window.ethereum) {
-            provider = new ethers.providers.Web3Provider(window.ethereum);
-        } else {
-            provider = new ethers.providers.JsonRpcProvider(sepoliaConfig.rpcUrl);
+        try {
+            if (window.ethereum) {
+                provider = new ethers.providers.Web3Provider(window.ethereum);
+            } else {
+                new URL(sepoliaConfig.rpcUrl);
+                provider = new ethers.providers.JsonRpcProvider(sepoliaConfig.rpcUrl);
+            }
+        } catch (err) {
+            showToast('Invalid RPC URL', 'error');
+            console.error('Provider initialization failed:', err);
+            throw err;
         }
 
         const GAS_MULTIPLIER = parseFloat(localStorage.getItem('gasMultiplier') || '1.15');

--- a/networkConfig.js
+++ b/networkConfig.js
@@ -1,5 +1,12 @@
 const RPC_URL = (typeof process !== 'undefined' && process.env && process.env.VITE_SEPOLIA_RPC_URL) || '';
 
+if (!RPC_URL) {
+  const msg = 'RPC_URL is not set. Initialization halted.';
+  if (typeof console !== 'undefined') console.error(msg);
+  if (typeof window !== 'undefined' && typeof window.alert === 'function') window.alert(msg);
+  throw new Error(msg);
+}
+
 window.networkConfig = {
   11155111: {
     chainIdHex: '0xaa36a7',


### PR DESCRIPTION
## Summary
- Stop initialization if `VITE_SEPOLIA_RPC_URL` is missing and alert the user
- Add error handling around provider creation for invalid RPC URLs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bde74ab814832f9584a31c4b932cc1