### PR TITLE
Refactor event handling with delegation for slippage and token list

### DIFF
--- a/app.js
+++ b/app.js
@@ -155,25 +155,29 @@
         });
         
         // Slippage button handlers
-        document.querySelectorAll('.slippage-btn').forEach(btn => {
-            btn.addEventListener('click', function() {
-                this.parentElement.querySelectorAll('.slippage-btn').forEach(b => b.classList.remove('active'));
-                this.classList.add('active');
-            });
-        });
-        
-        // Add smooth hover effects to token items
-        document.querySelectorAll('.token-item').forEach(item => {
-            item.addEventListener('mouseenter', function() {
-                this.querySelector('div').style.background = 'var(--bg-elev)';
-            });
-            item.addEventListener('mouseleave', function() {
-                this.querySelector('div').style.background = 'transparent';
+        document.querySelectorAll('.slippage-options').forEach(container => {
+            container.addEventListener('click', (event) => {
+                const btn = event.target.closest('.slippage-btn');
+                if (!btn || !container.contains(btn)) return;
+                container.querySelectorAll('.slippage-btn').forEach(b => b.classList.remove('active'));
+                btn.classList.add('active');
             });
         });
 
-        // Token selection via event delegation
+        // Token list interactions via event delegation
         document.querySelectorAll('.token-list').forEach(list => {
+            list.addEventListener('mouseenter', (event) => {
+                const item = event.target.closest('.token-item');
+                if (item && list.contains(item)) {
+                    item.classList.add('hover');
+                }
+            }, true);
+            list.addEventListener('mouseleave', (event) => {
+                const item = event.target.closest('.token-item');
+                if (item && list.contains(item)) {
+                    item.classList.remove('hover');
+                }
+            }, true);
             list.addEventListener('click', (event) => {
                 const tokenItem = event.target.closest('.token-item');
                 if (tokenItem) {

--- a/styles.css
+++ b/styles.css
@@ -413,7 +413,15 @@
             border-radius: 50%;
             background: linear-gradient(135deg, var(--brand), var(--info));
         }
-        
+
+        .token-item > div {
+            transition: background 0.2s;
+        }
+
+        .token-item.hover > div {
+            background: var(--bg-elev);
+        }
+
         /* Swap Interface */
         .swap-container {
             max-width: 480px;


### PR DESCRIPTION
## Summary
- Delegate slippage button clicks to their container for cleaner handling
- Use delegated hover and click events on token list items
- Add CSS class for token-item hover background

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68bd9e95e618832f8ddcfcdb45fab71e